### PR TITLE
170 improve record history

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,3 +617,32 @@ Busca as informações de um usuário pelo e-mail
   "updatedAt": "2021-11-06T03:05:20.572Z"
 }
 ```
+
+**POST `/records/:id/close`**
+
+Finaliza as tramitações de um registro
+
+- Body
+
+```json
+{
+  "closed_by": "",
+  "reason": ""
+}
+```
+
+- Resposta
+
+* HTTP 200 se o registro for fechado com sucesso
+* HTTP 400 se o registro já estiver fechado ou se reason é vazio
+
+**PSOT `/records/:id/reopen`**
+
+Reabre as tramitações de um registro
+
+```json
+{
+  "reopened_by": "",
+  "reason": ""
+}
+```

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "db:seeders:undo": "export DATABASE_URL=postgres://oraculo:oraculo123@localhost:5431/oraculo && npx sequelize db:seed:undo:all",
     "start": "node src/index.js",
     "start:prod": "node src/index.js",
-    "all": "yarn run docker:clean && yarn run docker:up && yarn run db:migrate && yarn run db:seeders",
-    "all:prod": "yarn docker:up && npx sequelize db:migrate && npx sequelize db:seed:all",
+    "all": "yarn run docker:clean && yarn run docker:up && yarn run db:migrate && sleep 5 && yarn run db:seeders",
+    "all:prod": "yarn docker:up && npx sequelize db:migrate && sleep 5 && npx sequelize db:seed:all",
     "update:all": "sudo docker-compose up -d --build"
   },
   "repository": {

--- a/src/Constants/errors.js
+++ b/src/Constants/errors.js
@@ -1,3 +1,4 @@
 const ERR_RECORD_NOT_FOUND = { error: "record not found" };
+const ERR_NO_ERROR = { message: "success" };
 
 module.exports = { ERR_RECORD_NOT_FOUND };

--- a/src/Constants/errors.js
+++ b/src/Constants/errors.js
@@ -1,4 +1,5 @@
 const ERR_RECORD_NOT_FOUND = { error: "record not found" };
 const ERR_NO_ERROR = { message: "success" };
+const ERR_STATUS_ALREADY_SET = { message: "this record status is already set" };
 
-module.exports = { ERR_RECORD_NOT_FOUND };
+module.exports = { ERR_RECORD_NOT_FOUND, ERR_NO_ERROR, ERR_STATUS_ALREADY_SET };

--- a/src/Controller/RecordController.js
+++ b/src/Controller/RecordController.js
@@ -438,7 +438,7 @@ async function closeRecord(req, res) {
 
   try {
     const result = await updateRecordStatus(Situation.StatusFinished, recordID);
-    if (result == ERR_RECORD_NOT_FOUND) {
+    if (result === ERR_RECORD_NOT_FOUND) {
       return res.status(404).json(result);
     } else if (result === ERR_STATUS_ALREADY_SET) {
       return res.status(400).json(result);
@@ -459,7 +459,7 @@ async function closeRecord(req, res) {
       closed_by,
       closed_at: new Date(),
       record_id: recordID,
-      reason: reason ? reason : null,
+      reason,
     });
 
     return res.status(200).json({ message: "record closed successfully" });
@@ -481,7 +481,7 @@ async function reopenRecord(req, res) {
 
   try {
     const result = await updateRecordStatus(Situation.StatusRunning, recordID);
-    if (result == ERR_RECORD_NOT_FOUND) {
+    if (result === ERR_RECORD_NOT_FOUND) {
       return res.status(404).json(result);
     } else if (result === ERR_STATUS_ALREADY_SET) {
       return res.status(400).json(result);
@@ -502,7 +502,7 @@ async function reopenRecord(req, res) {
       reopened_by,
       reopened_at: new Date(),
       record_id: recordID,
-      reason: reason ? reason : null,
+      reason,
     });
 
     return res.status(200).json({ message: "record reopened successfully" });

--- a/src/Controller/TagController.js
+++ b/src/Controller/TagController.js
@@ -1,40 +1,36 @@
 const { Tag } = require("../Model/Tag");
 
 async function createTag(req, res) {
-    const { name, color } = req.body;
+  const { name, color } = req.body;
 
-    try {
-        const newTag = await Tag.create({ name, color });
-        return res.status(200).json(newTag);
-    } catch (err) {
-        return res.status(500).json({ error: "could not create a new tag. try again" });
-    }
+  try {
+    const newTag = await Tag.create({ name, color });
+    return res.status(200).json(newTag);
+  } catch (err) {
+    return res.status(500).json({ error: "could not create a new tag. try again" });
+  }
 }
 
 async function listTags(req, res) {
-    try {
-        const tags = await Tag.findAll({ attributes: ["id", "name", "color"] });
-        return res.status(200).json(tags);
-    } catch (err) {
-        return res.status(500).json({ error: "could not list all tags" });
-    }
+  const tags = await Tag.findAll({ attributes: ["id", "name", "color"] });
+  return res.status(200).json(tags);
 }
 
 async function editTag(req, res) {
-    const { id } = req.params;
-    const { name, color } = req.body;
+  const { id } = req.params;
+  const { name, color } = req.body;
 
-    const existingTag = await Tag.findByPk(id);
-    if (!existingTag) {
-        return res.status(400).json({ error: "could not find the specified tag" });
-    }
+  const existingTag = await Tag.findByPk(id);
+  if (!existingTag) {
+    return res.status(404).json({ error: "could not find the specified tag" });
+  }
 
-    const editedTag = await existingTag.update({ name, color });
-    if (!editedTag) {
-        return res.status(500).json({ error: "could not edit the specified tag" });
-    }
+  const editedTag = await existingTag.update({ name, color });
+  if (!editedTag) {
+    return res.status(500).json({ error: "could not edit the specified tag" });
+  }
 
-    return res.status(200).json({ message: "the tag has been edited" });
+  return res.status(200).json({ message: "the tag has been edited" });
 }
 
 module.exports = { createTag, listTags, editTag };

--- a/src/Database/migrations/20211019041645-create-history.js
+++ b/src/Database/migrations/20211019041645-create-history.js
@@ -52,6 +52,10 @@ module.exports = {
         onUpdate: "CASCADE",
         onDelete: "CASCADE",
       },
+      reason: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
       created_at: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/src/Database/migrations/20211019041645-create-history.js
+++ b/src/Database/migrations/20211019041645-create-history.js
@@ -15,19 +15,35 @@ module.exports = {
       },
       origin_name: {
         type: Sequelize.TEXT,
-        allowNull: false,
+        allowNull: true,
       },
       destination_id: {
         type: Sequelize.INTEGER,
-        allowNull: false,
+        allowNull: true,
       },
       destination_name: {
         type: Sequelize.TEXT,
-        allowNull: false,
+        allowNull: true,
       },
       forwarded_by: {
         type: Sequelize.TEXT,
-        allowNull: false,
+        allowNull: true,
+      },
+      closed_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      closed_by: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      reopened_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      reopened_by: {
+        type: Sequelize.TEXT,
+        allowNull: true,
       },
       record_id: {
         type: Sequelize.INTEGER,

--- a/src/Model/History.js
+++ b/src/Model/History.js
@@ -7,11 +7,105 @@ class History extends Model {
         /**
          * Contém o email do usuário que encaminhou o registro
          */
-        forwarded_by: { type: DataTypes.TEXT },
-        origin_id: { type: DataTypes.INTEGER },
-        origin_name: { type: DataTypes.TEXT },
-        destination_id: { type: DataTypes.INTEGER },
-        destination_name: { type: DataTypes.TEXT },
+        origin_id: {
+          type: DataTypes.INTEGER,
+          get() {
+            const val = this.getDataValue("origin_id");
+            if (!val) {
+              return;
+            }
+
+            return val;
+          },
+        },
+        origin_name: {
+          type: DataTypes.TEXT,
+          get() {
+            const val = this.getDataValue("origin_name");
+            if (!val) {
+              return;
+            }
+
+            return val;
+          },
+        },
+        destination_id: {
+          type: DataTypes.INTEGER,
+          get() {
+            const val = this.getDataValue("destination_id");
+            if (!val) {
+              return;
+            }
+
+            return val;
+          },
+        },
+        destination_name: {
+          type: DataTypes.TEXT,
+          get() {
+            const val = this.getDataValue("destination_name");
+            if (!val) {
+              return;
+            }
+
+            return val;
+          },
+        },
+        forwarded_by: {
+          type: DataTypes.TEXT,
+          get() {
+            const val = this.getDataValue("forwarded_by");
+            if (!val) {
+              return;
+            }
+
+            return val;
+          },
+        },
+        closed_at: {
+          type: DataTypes.DATE,
+          get() {
+            const val = this.getDataValue("closed_at");
+            if (!val) {
+              return;
+            }
+
+            return val;
+          },
+        },
+        closed_by: {
+          type: DataTypes.TEXT,
+          get() {
+            const val = this.getDataValue("closed_by");
+            if (!val) {
+              return;
+            }
+
+            return val;
+          },
+        },
+        reopened_at: {
+          type: DataTypes.DATE,
+          get() {
+            const val = this.getDataValue("reopened_at");
+            if (!val) {
+              return;
+            }
+
+            return val;
+          },
+        },
+        reopened_by: {
+          type: DataTypes.TEXT,
+          get() {
+            const val = this.getDataValue("reopened_by");
+            if (!val) {
+              return;
+            }
+
+            return val;
+          },
+        },
       },
       {
         sequelize,

--- a/src/Model/History.js
+++ b/src/Model/History.js
@@ -12,6 +12,8 @@ class History extends Model {
           get() {
             const val = this.getDataValue("origin_id");
             if (!val) {
+              // isso é feito dessa forma pois só assim o sequelize entende que o campo deverá ser omitido
+              // da query. O sonarcloud aponta como code smell, mas isso é algo interno do sequelize
               return;
             }
 
@@ -99,6 +101,17 @@ class History extends Model {
           type: DataTypes.TEXT,
           get() {
             const val = this.getDataValue("reopened_by");
+            if (!val) {
+              return;
+            }
+
+            return val;
+          },
+        },
+        reason: {
+          type: DataTypes.TEXT,
+          get() {
+            const val = this.getDataValue("reason");
             if (!val) {
               return;
             }

--- a/src/routes.js
+++ b/src/routes.js
@@ -15,6 +15,8 @@ routes.get("/records/page/:page", RecordController.getRecordsByPage);
 routes.post("/records/:id/forward", RecordController.forwardRecord);
 routes.get("/records/:id/sections", RecordController.getRecordSectionsByID);
 routes.post("/records/:id/status", RecordController.setRecordSituation);
+routes.post("/records/:id/close", RecordController.closeRecord);
+routes.post("/records/:id/reopen", RecordController.reopenRecord);
 routes.get("/records/:id/history", RecordController.getRecordsHistory);
 routes.get("/records/:id/current-section", RecordController.findCurrentSection);
 routes.get("/count/records", RecordController.getTotalNumberOfRecords);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -371,6 +371,54 @@ describe("Main test", () => {
 
     expect(res.statusCode).toEqual(400);
   });
+
+  it("POST /records/:id/close - should not close a record (no reason)", async () => {
+    const res = await request(app)
+      .post("/records/1/close")
+      .send({ closed_by: "william@pcgo.com" });
+
+    expect(res.statusCode).toEqual(400);
+  });
+
+  it("POST /records/:id/close - should close a record", async () => {
+    const res = await request(app)
+      .post("/records/1/close")
+      .send({ closed_by: "william@pcgo.com", reason: "any reason" });
+
+    expect(res.statusCode).toEqual(200);
+  });
+
+  it("POST /records/:id/reopen - should reopen a record", async () => {
+    const res = await request(app)
+      .post("/records/1/reopen")
+      .send({ reopened_by: "william@pcgo.com", reason: "any reason" });
+
+    expect(res.statusCode).toEqual(200);
+  });
+
+  it("POST /records/:id/reopen - should not reopen a record (status already set)", async () => {
+    const res = await request(app)
+      .post("/records/1/reopen")
+      .send({ reopened_by: "william@pcgo.com", reason: "any reason" });
+
+    expect(res.statusCode).toEqual(400);
+  });
+
+  it("POST /records/:id/close - should not close (invalid field type)", async () => {
+    const res = await request(app)
+      .post("/records/1/close")
+      .send({ closed_by: 1, reason: "any reason" });
+
+    expect(res.statusCode).toEqual(500);
+  });
+
+  it("POST /records/:id/reopen - should not reopen (invalid field type)", async () => {
+    const res = await request(app)
+      .post("/records/1/reopen")
+      .send({ reopened_by: 1, reason: "any reason" });
+
+    expect(res.statusCode).toEqual(500);
+  });
 });
 
 afterAll((done) => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -373,14 +373,6 @@ describe("Main test", () => {
   });
 
   it("POST /records/:id/close - should not close a record (no reason)", async () => {
-    const res = await request(app)
-      .post("/records/1/close")
-      .send({ closed_by: "william@pcgo.com" });
-
-    expect(res.statusCode).toEqual(400);
-  });
-
-  it("POST /records/:id/close - should close a record", async () => {
     // Atualiza o status do registro para "pending" antes de fazer os demais testes
     const res1 = await request(app).post("/records/1/status").send({
       situation: "pending",
@@ -388,6 +380,22 @@ describe("Main test", () => {
 
     expect(res1.statusCode).toEqual(200);
 
+    const res = await request(app)
+      .post("/records/1/close")
+      .send({ closed_by: "william@pcgo.com" });
+
+    expect(res.statusCode).toEqual(400);
+  });
+
+  it("POST /records/:id/reopen - should not reopen a record (no reason)", async () => {
+    const res = await request(app)
+      .post("/records/1/reopen")
+      .send({ reopened_by: "william@pcgo.com" });
+
+    expect(res.statusCode).toEqual(400);
+  });
+
+  it("POST /records/:id/close - should close a record", async () => {
     const res = await request(app)
       .post("/records/1/close")
       .send({ closed_by: "william@pcgo.com", reason: "any reason" });
@@ -425,6 +433,22 @@ describe("Main test", () => {
       .send({ reopened_by: 1, reason: "any reason" });
 
     expect(res.statusCode).toEqual(404);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("POST /records/:id/reopen - should not reopen (no user information)", async () => {
+    // Atualiza o status do registro para "pending" antes de fazer os demais testes
+    const res1 = await request(app).post("/records/1/status").send({
+      situation: "pending",
+    });
+
+    expect(res1.statusCode).toEqual(200);
+
+    const res = await request(app)
+      .post("/records/1/reopen")
+      .send({ reason: "any reason" });
+
+    expect(res.statusCode).toEqual(400);
     expect(res.body.error).toBeDefined();
   });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -452,6 +452,27 @@ describe("Main test", () => {
     expect(res.body.error).toBeDefined();
   });
 
+  it("POST /records/:id/close - should not reopen (record not found)", async () => {
+    const res = await request(app).post("/records/500/close");
+    expect(res.statusCode).toEqual(404);
+  });
+
+  it("POST /records/:id/close - should not close (already closed)", async () => {
+    // Atualiza o status do registro para "finished" antes de fazer os demais testes
+    const res1 = await request(app).post("/records/1/status").send({
+      situation: "finished",
+    });
+
+    expect(res1.statusCode).toEqual(200);
+
+    const res = await request(app)
+      .post("/records/1/reopen")
+      .send({ closed_by: "william@pcgo.com", reason: "any reason" });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.message).toBeDefined();
+  });
+
   it("GET /sections - should list get all existing sections", async () => {
     const res = await request(app).get("/sections");
     expect(res.statusCode).toEqual(200);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -453,7 +453,9 @@ describe("Main test", () => {
   });
 
   it("POST /records/:id/close - should not reopen (record not found)", async () => {
-    const res = await request(app).post("/records/500/close");
+    const res = await request(app)
+      .post("/records/500/close")
+      .send({ reason: "any reason" });
     expect(res.statusCode).toEqual(404);
   });
 
@@ -470,7 +472,6 @@ describe("Main test", () => {
       .send({ closed_by: "william@pcgo.com", reason: "any reason" });
 
     expect(res.statusCode).toEqual(400);
-    expect(res.body.message).toBeDefined();
   });
 
   it("GET /sections - should list get all existing sections", async () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -381,6 +381,13 @@ describe("Main test", () => {
   });
 
   it("POST /records/:id/close - should close a record", async () => {
+    // Atualiza o status do registro para "pending" antes de fazer os demais testes
+    const res1 = await request(app).post("/records/1/status").send({
+      situation: "pending",
+    });
+
+    expect(res1.statusCode).toEqual(200);
+
     const res = await request(app)
       .post("/records/1/close")
       .send({ closed_by: "william@pcgo.com", reason: "any reason" });
@@ -417,7 +424,8 @@ describe("Main test", () => {
       .post("/records/1/reopen")
       .send({ reopened_by: 1, reason: "any reason" });
 
-    expect(res.statusCode).toEqual(500);
+    expect(res.statusCode).toEqual(404);
+    expect(res.body.error).toBeDefined();
   });
 });
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -451,6 +451,17 @@ describe("Main test", () => {
     expect(res.statusCode).toEqual(400);
     expect(res.body.error).toBeDefined();
   });
+
+  it("GET /sections - should list get all existing sections", async () => {
+    const res = await request(app).get("/sections");
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toBeDefined();
+  });
+
+  it("POST /tag/:id/edit - should not edit a tag (inexistent tag)", async () => {
+    const res = await request(app).post("/tag/500/edit");
+    expect(res.statusCode).toEqual(404);
+  });
 });
 
 afterAll((done) => {


### PR DESCRIPTION
**Issue** closes fga-eps-mds/2021.1-Oraculo#170

Descrição
- [x] adiciona endpoints específicos para fechar ou reabrir a tramitação de um registro
- [x] adiciona o histórico de reabertura e conclusão de um registro no banco de dados
- [x] adiciona o campo `reason` para armazenar o motivo de fechamento/reabertura de um registro

Observação:
- estou ciente dos code smells, porém foi a única forma funcional que encontrei de omitir os campos "null" da resposta enviada pelo server HTTP. Tentei outras formas, mas essa foi a única que funcionou